### PR TITLE
Fix: awt.Robot resets mouse speed to 10 (Windows)

### DIFF
--- a/src/windows/native/sun/windows/awt_Robot.cpp
+++ b/src/windows/native/sun/windows/awt_Robot.cpp
@@ -65,6 +65,12 @@ void AwtRobot::MouseMove( jint x, jint y)
       newAccel[2] = 0;
       newSpeed = 10;
 
+      // On x64, SPI_GETMOUSESPEED returns 32-bit value (which sets only 32 bits 
+      // of oldSpeed variable), while SPI_SETMOUSESPEED requires 64-bit value.
+      // As oldSpeed is 64-bit variable, initialize it to 0 to avoid passing
+      // uninitialized memory in SPI_SETMOUSESPEED call.
+      oldSpeed = 0;
+
       // Save the Current Mouse Acceleration Constants
       bResult = SystemParametersInfo(SPI_GETMOUSE,0,oldAccel,0);
       bResult = SystemParametersInfo(SPI_GETMOUSESPEED, 0, &oldSpeed,0);


### PR DESCRIPTION
The issue affects only x64 Windows.

Windows implementation of awt.Robot has a workaround for a limitation
of mouse_event API: absolute movement with mouse_event works only
for positions that are on primary display. This behavior was there since
Windows 95 and was revised in Windows 2000 Beta 3. Since then
mouse_event works with multiple displays for both relative and absolute
events. The workaround stayed in the code even though Windows 98 is no
longer supported by Java Runtime.

The workaround proposed in KB 193003 (and implemented here) has a bug
that makes it broken on x64 platforms (note that back then Windows
supported only x86 platform).

SystemParametersInfo on SPI_GETMOUSESPEED action treats pvParam as a
pointer to 32-bit INT where it returns current mouse speed (a value in a
range of 1 to 20). But SPI_SETTMOUSESPEED treats pvParam as a integer value
with a size of platform's pointer (which is 64-bit on x64). The call to
SPI_GETMOUSESPEED sets only lowest 32-bits of the oldSpeed variable.
The other 32-bits are left uninitialized (stack variables are not
zero-initialized). Second call to SPI_SETTMOUSESPEED will fail if these bits
of oldSpeed were non-zero due to pvParam being out of 1 to 20 int range.

Fix:
Initialize oldSpeed to 0.

See Android Studio bug for more info: https://issuetracker.google.com/37135102

Relevant Microsoft KB articles:
193003 PRB: mouse_event and Absolute Moves on Secondary Monitors
193005 INFO: mouse_event Different Between Windows 2000 Beta & Win 98