### PR TITLE
Fix an off-by-one strncmp in gtk3_interface.c

### DIFF
--- a/src/solaris/native/sun/awt/gtk3_interface.c
+++ b/src/solaris/native/sun/awt/gtk3_interface.c
@@ -2806,7 +2806,7 @@ static void transform_detail_string (const gchar *detail,
       fp_gtk_style_context_set_junction_sides (context, GTK_JUNCTION_TOP);
     }
   else if ((detail[0] == 'h' || detail[0] == 'v') &&
-           strncmp (&detail[1], "scrollbar_", 9) == 0)
+           strncmp (&detail[1], "scrollbar_", 10) == 0)
     {
       fp_gtk_style_context_add_class (context, "button");
       fp_gtk_style_context_add_class (context, "scrollbar");


### PR DESCRIPTION
The `"scrollbar_"` is 10B and we compared only 9B (cutting of the `_` char).

This was found with a "cstrnfinder" research and I haven't tested this change (more info https://twitter.com/disconnect3d_pl/status/1339757359896408065). Close this PR if this change is incorrect.