### PR TITLE
Set the HttpConnection State when close request InputStream manually

### DIFF
--- a/src/share/classes/sun/net/httpserver/ChunkedInputStream.java
+++ b/src/share/classes/sun/net/httpserver/ChunkedInputStream.java
@@ -150,6 +150,16 @@ class ChunkedInputStream extends LeftOverInputStream {
         }
     }
 
+    @Override
+    public void close() throws IOException {
+        super.close();
+        // Set the state when close request InputStream manually
+        remaining = 0;
+        if (t.getConnection().getState() != HttpConnection.State.RESPONSE) {
+            t.getServerImpl().requestCompleted (t.getConnection());
+        }
+    }
+
     /**
      * returns the number of bytes available to read in the current chunk
      * which may be less than the real amount, but we'll live with that

--- a/src/share/classes/sun/net/httpserver/FixedLengthInputStream.java
+++ b/src/share/classes/sun/net/httpserver/FixedLengthInputStream.java
@@ -63,6 +63,16 @@ class FixedLengthInputStream extends LeftOverInputStream {
         return n;
     }
 
+    @Override
+    public void close() throws IOException {
+        super.close();
+        // Set the state when close request InputStream manually
+        remaining = 0;
+        if (t.getConnection().getState() != HttpConnection.State.RESPONSE) {
+            t.getServerImpl().requestCompleted (t.getConnection());
+        }
+    }
+
     public int available () throws IOException {
         if (eof) {
             return 0;

--- a/src/share/share.iml
+++ b/src/share/share.iml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8" inherit-compiler-output="true">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/classes" isTestSource="false" />
-      <excludeFolder url="file://$MODULE_DIR$/classes/com/sun/jmx/snmp" />
-      <excludeFolder url="file://$MODULE_DIR$/classes/sun/dc" />
-      <excludeFolder url="file://$MODULE_DIR$/classes/sun/management/snmp" />
     </content>
-    <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="windows" />
+    <orderEntry type="module" module-name="solaris" />
   </component>
 </module>


### PR DESCRIPTION
Fixed: Close request InputStream manually if not read request InputStream to end, then send response will throw java.lang.AssertionError

The Issue Sample:

```Java
        InputStream byteArrayInputStream = null;
        FileOutputStream fileOutputStream = null;
        try {
            byteArrayInputStream = mHttpExchange.getRequestBody();
            fileOutputStream = new FileOutputStream(fileDownload);
            byte[] buffer = new byte[LocalNetConfig.BUFFER_SIZE];

            while ((size = byteArrayInputStream.read(buffer)) > 0 && !isCanceled) {
                fileOutputStream.write(buffer, 0, size);
            }

        } catch (IOException e) {
            e.printStackTrace();
        } finally {
            try {

                if (byteArrayInputStream != null) {
                    byteArrayInputStream.close();
                }

                if (fileOutputStream != null) {
                    fileOutputStream.close();
                }
            } catch (Exception ignore) {

            }

           // =================================================================
           // If isCanceled = true, the code of below will throw java.lang.AssertionError
          // =================================================================
           final OutputStream responseBody = mHttpExchange.getResponseBody();
            mHttpExchange.sendResponseHeaders(HttpStatusCode.OK, 0);

            String responseBodyString = "";
            final byte[] responseBodyStringBytes = responseBodyString.getBytes(StandardCharsets.UTF_8);
            responseBody.write(responseBodyStringBytes, 0, responseBodyStringBytes.length);
            responseBody.flush();
            responseBody.close();
        }
    }

```